### PR TITLE
和暦から西暦に変換するアプリを作成しました

### DIFF
--- a/src/app/Minutes.php
+++ b/src/app/Minutes.php
@@ -18,7 +18,7 @@ class Minutes
 
     public function toSeconds(): Seconds
     {
-        $seconds = $this->minutes * 60;
+        $seconds = $this->minutes + 2018;
         return new Seconds($seconds);
     }
 }

--- a/src/public/sample/index.php
+++ b/src/public/sample/index.php
@@ -6,7 +6,7 @@ unset($_SESSION['errorMessage']);
 
 <body>
 
-<h1>分を秒に変換しよう</h1>
+<h1>和暦を西暦に変換しよう</h1>
 
 <p><?php echo $errorMessage; ?></p>
 
@@ -15,13 +15,13 @@ unset($_SESSION['errorMessage']);
     <table>
 
       <tr>
-        <td><p>時間(分)</p></td>
-        <td><p><input type="number" name="time" placeholder="分"></p></td>
+        <td><p>令和</p></td>
+        <td><p><input type="number" name="time" placeholder="年"></p></td>
       </tr>
 
     </table>
 
-    <input type="submit" value="何秒か確認してみよう"> 
+    <input type="submit" value="西暦何年か確認してみよう"> 
 
   </form>
 


### PR DESCRIPTION
### 作業した教材のURL

[https://www.notion.so/9cf9452e2a504c6db89375c3f8a825c0?pvs=4](url)

### 作成したページのURL

[http://localhost:8080/sample/index.php](url)  
[http://localhost:8080/sample/answer.php](url)  


### 作業詳細
和暦から西暦に変換するアプリ

https://github.com/AsukaKanematsu/year-advanced-course-class/assets/129743465/17530698-74fc-4cad-b113-ae6a262ee8f2


コードを編集して実行したらクラスの課題をやったときみたいに  \ が  ¥  と認識されてしまうエラーメッセージがでました(´；ω；`)

言語設定を変えたりしてみましたが解決できなかったです(´；ω；`)

![localhost_8080_sample_answer php - Google Chrome 2023_06_24 1_25_21](https://github.com/AsukaKanematsu/year-advanced-course-class/assets/129743465/e201692c-e216-4fd1-8907-9f1243359a5c)

